### PR TITLE
feat: 死活監視 Synthetics canary を追加（/tags SSR・/photo-viewer OGP の継続監視）[Issue#148]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,16 @@ jobs:
         fi
         node --test "${files[@]}"
 
+    - name: Run Node.js tests for SEO canary checks (Issue#148)
+      run: |
+        shopt -s nullglob
+        files=(scripts/canary/__tests__/*.test.js)
+        if [ ${#files[@]} -eq 0 ]; then
+          echo "No canary tests to run."
+          exit 0
+        fi
+        node --test "${files[@]}"
+
   tdd-status:
     name: TDD Status Check
     runs-on: ubuntu-latest

--- a/scripts/canary/README.md
+++ b/scripts/canary/README.md
@@ -1,0 +1,64 @@
+# SEO 死活監視 canary（Issue#148）
+
+本番 `https://photlas.jp` の SEO 重要 URL を **30 分おき**に外形監視する CloudWatch Synthetics canary。
+「CloudFront 経路漏れで S3 の SPA 殻が無言で返る」「`X-Robots-Tag: noindex` 誤付与」等、
+**デプロイとは無関係に発生する配信障害**を継続検知する（デプロイ時スモークテストは別途 `deploy.yml`）。
+
+- 設計の真実: `documents/04_Issues/Issue#148.md`
+- 受け入れ基準: 同 §6.1
+
+## 構成
+
+| ファイル | 役割 | テスト |
+|---|---|---|
+| `checks.mjs` | 検証ロジック（純粋関数） | `__tests__/checks.test.js`（`node --test`、CI 対象） |
+| `seo-canary.js` | Synthetics handler（HTTP 取得＋ランタイム連携の薄いラッパー） | ランタイム依存のため単体テスト対象外 |
+| `../setup-synthetics-canary.sh` | デプロイ（冪等。canary / IAM / S3 / アラーム） | `tests/scripts/setup-synthetics-canary.bats` |
+
+## 監視内容（各実行でチェック）
+
+`/tags/{slug}?lang=ja`（GET・リダイレクト非追従）:
+- HTTP 200 / `hreflang=` が 5 以上 / `canonical` が `https://photlas.jp/` 絶対 URL / `X-Robots-Tag: noindex` が無い
+
+`/photo-viewer/{id}`（GET）:
+- HTTP 200 / `og:url` が `https://photlas.jp/photo-viewer/{id}` / `og:image` が CDN サムネ（`og-image.png` でない）/ `X-Robots-Tag: noindex` が無い
+
+監視対象の slug/id は `sitemap-tags.xml` / `sitemap-photos-0.xml` から実行時に動的取得する。
+**ハイブリッド挙動**: sitemap が壊れている（5xx・XML でなく HTML 等）なら失敗、正常だが 0 件（公開写真ゼロ等）ならその URL はスキップ（コールドスタート期の誤報防止）。
+
+## デプロイ
+
+```bash
+# 前提: SNS topic photlas-waf-alerts（本番アラート集約先、setup-waf-alarms.sh で作成）が存在し、
+#       メール購読が confirmed であること（未確認だとアラートが届かない）。
+./scripts/setup-synthetics-canary.sh
+```
+
+冪等。再実行すると canary は update、アラームは上書きされる。
+
+## アラート発報時の triage runbook
+
+アラーム `photlas-seo-canary-SuccessPercent` は **2 回連続失敗**で発報する（一過性の瞬断は無視）。
+発報したら、まず CloudWatch Synthetics コンソールで **失敗実行のログ／スクショ**を見て、どの URL の
+どの条件で落ちたかを特定し、以下を順に確認する。
+
+1. **CloudFront ビヘイビア** — `/tags/*`・`/photo-viewer/*` が backend オリジン（ALB）に向くビヘイビアが
+   消えていないか／別オリジン（S3）に吸われていないか。今回の発生元事故がこれ。
+2. **ALB リスナールール** — 上記パスを backend ターゲットグループへ振り分けるルールの誤削除・優先度変更。
+3. **backend** — フィルタ変更による `X-Robots-Tag: noindex` 誤付与（`XRobotsTagFilter`）、SSR の退化。
+   `curl -sI https://photlas.jp/tags/<slug>?lang=ja` でヘッダを直接確認。
+4. **証明書 / ドメイン / オリジン到達性** — 証明書失効、DNS、オリジンの 5xx 等。
+
+> 補足: sitemap が壊れているとの失敗（`sitemap delivery broken`）なら、まず backend（`/api/v1/sitemap-*.xml`）の
+> 配信そのものを疑う。`hreflang count 0` や `og:url is https://photlas.jp/` は **S3 殻が返っている**典型サイン。
+
+## 発報の動作確認（受け入れ基準 E-4）
+
+意図的に条件を満たさない状態を作り、アラートが飛ぶことを一度確認する。例:
+- 監視対象 slug を一時的に存在しない値へ差し替えてデプロイ → 2 連続失敗で発報 → 復旧で OK 通知、を確認。
+- 確認後は必ず元に戻す。
+
+## コスト
+
+CloudWatch Synthetics は実行回数課金。1 canary・30 分間隔で月 ~1,440 実行、**月数百円程度**の想定。
+頻度を上げる場合は `setup-synthetics-canary.sh` の `SCHEDULE_EXPRESSION` を変更する。

--- a/scripts/canary/__tests__/checks.test.js
+++ b/scripts/canary/__tests__/checks.test.js
@@ -1,0 +1,266 @@
+// Issue#148: 死活監視 canary の検証ロジック（純粋関数）のテスト。
+//
+// scripts/canary/checks.mjs は、本番 photlas.jp の /tags・/photo-viewer を
+// 外形監視するために「レスポンス本文・ヘッダから §3 の条件を満たすか」を
+// 判定する純粋関数群。ネットワークや AWS Synthetics ランタイムに依存しないため、
+// ここで単体テストして退化を防ぐ（実際の HTTP 取得・Synthetics 連携は
+// seo-canary.js 側＝ランタイム依存のため本テスト対象外）。
+//
+// Source of truth: documents/04_Issues/Issue#148.md §3 / §4.1 / §4.2
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const MODULE_PATH = path.resolve(__dirname, '..', 'checks.mjs');
+
+async function load() {
+  return import(MODULE_PATH);
+}
+
+// ---- フィクスチャ -----------------------------------------------------------
+
+// SSR が効いた /tags ページ（5 言語 + x-default = hreflang 6 個、絶対 canonical）。
+const TAGS_SSR_BODY = `<!DOCTYPE html><html lang="ja"><head>
+<link rel="canonical" href="https://photlas.jp/tags/sakura?lang=ja" />
+<link rel="alternate" hreflang="ja" href="https://photlas.jp/tags/sakura?lang=ja" />
+<link rel="alternate" hreflang="en" href="https://photlas.jp/tags/sakura?lang=en" />
+<link rel="alternate" hreflang="zh" href="https://photlas.jp/tags/sakura?lang=zh" />
+<link rel="alternate" hreflang="ko" href="https://photlas.jp/tags/sakura?lang=ko" />
+<link rel="alternate" hreflang="es" href="https://photlas.jp/tags/sakura?lang=es" />
+<link rel="alternate" hreflang="x-default" href="https://photlas.jp/tags/sakura?lang=ja" />
+</head><body>...</body></html>`;
+
+// S3 の SPA 殻（SSR されていない＝事故時に返る HTML。hreflang 0・canonical は site root）。
+const SPA_SHELL_BODY = `<!DOCTYPE html><html lang="ja"><head>
+<link rel="canonical" href="https://photlas.jp/" />
+<meta property="og:url" content="https://photlas.jp/" />
+<meta property="og:image" content="https://photlas.jp/og-image.png" />
+</head><body><div id="root"></div></body></html>`;
+
+// 個別 OGP が差し込まれた /photo-viewer ページ。
+const PHOTO_INJECTED_BODY = `<!DOCTYPE html><html lang="ja"><head>
+<meta property="og:url" content="https://photlas.jp/photo-viewer/123" />
+<meta property="og:image" content="https://d111111abcdef8.cloudfront.net/thumbnails/abc.jpg" />
+</head><body><div id="root"></div></body></html>`;
+
+const SITEMAP_TAGS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://photlas.jp/tags/sakura?lang=ja</loc></url>
+<url><loc>https://photlas.jp/tags/mountain?lang=ja</loc></url>
+</urlset>`;
+
+const SITEMAP_TAGS_EMPTY_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</urlset>`;
+
+const SITEMAP_PHOTOS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>https://photlas.jp/photo-viewer/123</loc></url>
+<url><loc>https://photlas.jp/photo-viewer/456</loc></url>
+</urlset>`;
+
+// =====================================================================
+// 抽出系の純粋関数
+// =====================================================================
+
+test('countHreflang: SSR ページは 5 以上', async () => {
+  const { countHreflang } = await load();
+  assert.ok(countHreflang(TAGS_SSR_BODY) >= 5);
+});
+
+test('countHreflang: SPA 殻は 0', async () => {
+  const { countHreflang } = await load();
+  assert.equal(countHreflang(SPA_SHELL_BODY), 0);
+});
+
+test('extractCanonical: href を取り出す', async () => {
+  const { extractCanonical } = await load();
+  assert.equal(extractCanonical(TAGS_SSR_BODY), 'https://photlas.jp/tags/sakura?lang=ja');
+});
+
+test('extractCanonical: 無ければ null', async () => {
+  const { extractCanonical } = await load();
+  assert.equal(extractCanonical('<html><head></head></html>'), null);
+});
+
+test('extractMetaContent: og:url を取り出す', async () => {
+  const { extractMetaContent } = await load();
+  assert.equal(
+    extractMetaContent(PHOTO_INJECTED_BODY, 'og:url'),
+    'https://photlas.jp/photo-viewer/123',
+  );
+});
+
+test('extractMetaContent: og:image を取り出す', async () => {
+  const { extractMetaContent } = await load();
+  assert.equal(
+    extractMetaContent(PHOTO_INJECTED_BODY, 'og:image'),
+    'https://d111111abcdef8.cloudfront.net/thumbnails/abc.jpg',
+  );
+});
+
+test('hasNoindex: noindex を含むヘッダ値は true', async () => {
+  const { hasNoindex } = await load();
+  assert.equal(hasNoindex('noindex, nofollow'), true);
+  assert.equal(hasNoindex('NOINDEX'), true);
+});
+
+test('hasNoindex: 未設定や index は false', async () => {
+  const { hasNoindex } = await load();
+  assert.equal(hasNoindex(undefined), false);
+  assert.equal(hasNoindex(null), false);
+  assert.equal(hasNoindex('index, follow'), false);
+});
+
+test('getHeader: 大文字小文字を無視して取得', async () => {
+  const { getHeader } = await load();
+  assert.equal(getHeader({ 'x-robots-tag': 'noindex' }, 'X-Robots-Tag'), 'noindex');
+  assert.equal(getHeader({ 'X-Robots-Tag': 'noindex' }, 'x-robots-tag'), 'noindex');
+  assert.equal(getHeader({}, 'x-robots-tag'), undefined);
+});
+
+// =====================================================================
+// /tags ページのチェック（§3）
+// =====================================================================
+
+test('checkTagsPage: 正常な SSR ページは合格', async () => {
+  const { checkTagsPage } = await load();
+  const result = checkTagsPage(
+    { status: 200, headers: {}, body: TAGS_SSR_BODY },
+    { slug: 'sakura' },
+  );
+  assert.equal(result.passed, true, JSON.stringify(result.failures));
+  assert.equal(result.failures.length, 0);
+});
+
+test('checkTagsPage: SPA 殻（hreflang 0・canonical が site root）は不合格', async () => {
+  const { checkTagsPage } = await load();
+  const result = checkTagsPage(
+    { status: 200, headers: {}, body: SPA_SHELL_BODY },
+    { slug: 'sakura' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /hreflang/i.test(f)));
+});
+
+test('checkTagsPage: X-Robots-Tag noindex が付いていたら不合格', async () => {
+  const { checkTagsPage } = await load();
+  const result = checkTagsPage(
+    { status: 200, headers: { 'x-robots-tag': 'noindex, nofollow' }, body: TAGS_SSR_BODY },
+    { slug: 'sakura' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /robots|noindex/i.test(f)));
+});
+
+test('checkTagsPage: HTTP 200 でなければ不合格', async () => {
+  const { checkTagsPage } = await load();
+  const result = checkTagsPage(
+    { status: 301, headers: {}, body: '' },
+    { slug: 'sakura' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /200|status/i.test(f)));
+});
+
+// =====================================================================
+// /photo-viewer ページのチェック（§3）
+// =====================================================================
+
+test('checkPhotoViewerPage: 個別 OGP 差し込み済みは合格', async () => {
+  const { checkPhotoViewerPage } = await load();
+  const result = checkPhotoViewerPage(
+    { status: 200, headers: {}, body: PHOTO_INJECTED_BODY },
+    { id: '123' },
+  );
+  assert.equal(result.passed, true, JSON.stringify(result.failures));
+  assert.equal(result.failures.length, 0);
+});
+
+test('checkPhotoViewerPage: og:url が site root（未注入）は不合格', async () => {
+  const { checkPhotoViewerPage } = await load();
+  const result = checkPhotoViewerPage(
+    { status: 200, headers: {}, body: SPA_SHELL_BODY },
+    { id: '123' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /og:url/i.test(f)));
+});
+
+test('checkPhotoViewerPage: og:image が汎用 og-image.png は不合格', async () => {
+  const { checkPhotoViewerPage } = await load();
+  // og:url は正しいが og:image だけ汎用にフォールバックしているケース
+  const body = `<meta property="og:url" content="https://photlas.jp/photo-viewer/123" />
+<meta property="og:image" content="https://photlas.jp/og-image.png" />`;
+  const result = checkPhotoViewerPage(
+    { status: 200, headers: {}, body },
+    { id: '123' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /og:image/i.test(f)));
+});
+
+test('checkPhotoViewerPage: X-Robots-Tag noindex は不合格', async () => {
+  const { checkPhotoViewerPage } = await load();
+  const result = checkPhotoViewerPage(
+    { status: 200, headers: { 'X-Robots-Tag': 'noindex, nofollow' }, body: PHOTO_INJECTED_BODY },
+    { id: '123' },
+  );
+  assert.equal(result.passed, false);
+  assert.ok(result.failures.some((f) => /robots|noindex/i.test(f)));
+});
+
+// =====================================================================
+// sitemap からの対象選択（ハイブリッド：壊れてる=fail / 空=skip）§4.2
+// =====================================================================
+
+test('selectTagSlug: 200 + slug あり → check', async () => {
+  const { selectTagSlug } = await load();
+  const r = selectTagSlug({ status: 200, contentType: 'application/xml', body: SITEMAP_TAGS_XML });
+  assert.equal(r.action, 'check');
+  assert.equal(r.slug, 'sakura');
+});
+
+test('selectTagSlug: 200 + 空 urlset → skip', async () => {
+  const { selectTagSlug } = await load();
+  const r = selectTagSlug({ status: 200, contentType: 'application/xml', body: SITEMAP_TAGS_EMPTY_XML });
+  assert.equal(r.action, 'skip');
+});
+
+test('selectTagSlug: 200 だが SPA 殻 HTML が返る → fail（配信障害）', async () => {
+  const { selectTagSlug } = await load();
+  const r = selectTagSlug({ status: 200, contentType: 'text/html', body: SPA_SHELL_BODY });
+  assert.equal(r.action, 'fail');
+});
+
+test('selectTagSlug: 5xx → fail', async () => {
+  const { selectTagSlug } = await load();
+  const r = selectTagSlug({ status: 503, contentType: 'text/html', body: 'err' });
+  assert.equal(r.action, 'fail');
+});
+
+test('selectPhotoId: 200 + id あり → check', async () => {
+  const { selectPhotoId } = await load();
+  const r = selectPhotoId({ status: 200, contentType: 'application/xml', body: SITEMAP_PHOTOS_XML });
+  assert.equal(r.action, 'check');
+  assert.equal(r.id, '123');
+});
+
+test('selectPhotoId: 404（公開写真なし）→ skip', async () => {
+  const { selectPhotoId } = await load();
+  const r = selectPhotoId({ status: 404, contentType: 'application/json', body: '' });
+  assert.equal(r.action, 'skip');
+});
+
+test('selectPhotoId: 500 → fail', async () => {
+  const { selectPhotoId } = await load();
+  const r = selectPhotoId({ status: 500, contentType: 'text/html', body: 'err' });
+  assert.equal(r.action, 'fail');
+});
+
+test('selectPhotoId: 200 だが HTML 殻 → fail（配信障害）', async () => {
+  const { selectPhotoId } = await load();
+  const r = selectPhotoId({ status: 200, contentType: 'text/html', body: SPA_SHELL_BODY });
+  assert.equal(r.action, 'fail');
+});

--- a/scripts/canary/checks.mjs
+++ b/scripts/canary/checks.mjs
@@ -1,0 +1,237 @@
+// Issue#148: 死活監視 canary の検証ロジック（純粋関数）。
+//
+// 本番 photlas.jp の /tags（SSR ランディング）・/photo-viewer（個別 OGP）を外形監視し、
+// 「CloudFront 経路漏れで S3 の SPA 殻が無言で返る」「X-Robots-Tag: noindex 誤付与」等の
+// 退化を継続検知する。ここはネットワーク・AWS Synthetics ランタイムに依存しない純粋関数のみ
+// （実際の HTTP 取得・Synthetics 連携は seo-canary.js）。
+//
+// Source of truth: documents/04_Issues/Issue#148.md §3 / §4.1 / §4.2
+
+/** SSR の証拠とみなす hreflang の最小個数（§3。SSR は 5 言語 + x-default、S3 殻は 0）。 */
+export const HREFLANG_MIN_COUNT = 5;
+
+/** 本番サイトのオリジン（canonical / og:url の絶対 URL 前提＝§3）。 */
+export const SITE_ORIGIN = 'https://photlas.jp';
+
+/** 個別 OGP が未注入のときに残る汎用 og:image（§3。これが残る＝差し込み失敗）。 */
+export const GENERIC_OG_IMAGE = `${SITE_ORIGIN}/og-image.png`;
+
+// ---- 抽出系 -----------------------------------------------------------------
+
+/**
+ * 本文中の `hreflang=` の出現回数を数える。
+ * @param {string} body レスポンス本文
+ * @returns {number}
+ */
+export function countHreflang(body) {
+  if (!body) {
+    return 0;
+  }
+  const matches = body.match(/hreflang=/g);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * `<link rel="canonical" href="...">` の href を取り出す（属性順は問わない）。
+ * @param {string} body レスポンス本文
+ * @returns {string|null} 見つからなければ null
+ */
+export function extractCanonical(body) {
+  if (!body) {
+    return null;
+  }
+  const linkTags = body.match(/<link\b[^>]*>/gi) || [];
+  for (const tag of linkTags) {
+    if (/\brel=["']canonical["']/i.test(tag)) {
+      const href = tag.match(/\bhref=["']([^"']*)["']/i);
+      return href ? href[1] : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * `<meta property|name="ATTR" content="...">` の content を取り出す（属性順は問わない）。
+ * @param {string} body レスポンス本文
+ * @param {string} attr property/name の値（例: og:url）
+ * @returns {string|null} 見つからなければ null
+ */
+export function extractMetaContent(body, attr) {
+  if (!body) {
+    return null;
+  }
+  const metaTags = body.match(/<meta\b[^>]*>/gi) || [];
+  const attrPattern = new RegExp(`\\b(?:property|name)=["']${escapeRegExp(attr)}["']`, 'i');
+  for (const tag of metaTags) {
+    if (attrPattern.test(tag)) {
+      const content = tag.match(/\bcontent=["']([^"']*)["']/i);
+      return content ? content[1] : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * ヘッダ値に noindex が含まれるか（大文字小文字を無視）。
+ * @param {string|null|undefined} value X-Robots-Tag の値
+ * @returns {boolean}
+ */
+export function hasNoindex(value) {
+  return typeof value === 'string' && /noindex/i.test(value);
+}
+
+/**
+ * ヘッダオブジェクトからキー名を大文字小文字無視で取得する。
+ * @param {Record<string,string>} headers
+ * @param {string} name
+ * @returns {string|undefined}
+ */
+export function getHeader(headers, name) {
+  if (!headers) {
+    return undefined;
+  }
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) {
+      return headers[key];
+    }
+  }
+  return undefined;
+}
+
+// ---- ページ単位のチェック（§3） ---------------------------------------------
+
+/**
+ * /tags/{slug}?lang=ja の SSR が退化していないか検証する。
+ * @param {{status:number, headers:Record<string,string>, body:string}} response
+ * @param {{slug:string}} _ctx 監視対象 slug（メッセージ用）
+ * @returns {{passed:boolean, failures:string[]}}
+ */
+export function checkTagsPage(response, { slug } = {}) {
+  const failures = [];
+  const { status, headers, body } = response;
+
+  if (status !== 200) {
+    failures.push(`HTTP status ${status} (expected 200) for /tags/${slug}`);
+  }
+  const hreflangCount = countHreflang(body);
+  if (hreflangCount < HREFLANG_MIN_COUNT) {
+    failures.push(`hreflang count ${hreflangCount} < ${HREFLANG_MIN_COUNT} (SSR not served? S3 shell?)`);
+  }
+  const canonical = extractCanonical(body);
+  if (!canonical || !canonical.startsWith(`${SITE_ORIGIN}/`)) {
+    failures.push(`canonical is not an absolute ${SITE_ORIGIN} URL: ${canonical}`);
+  }
+  const xRobotsTag = getHeader(headers, 'x-robots-tag');
+  if (hasNoindex(xRobotsTag)) {
+    failures.push(`X-Robots-Tag noindex present: ${xRobotsTag}`);
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+/**
+ * /photo-viewer/{id} の個別 OGP が差し込まれているか検証する。
+ * @param {{status:number, headers:Record<string,string>, body:string}} response
+ * @param {{id:string}} ctx 監視対象 id
+ * @returns {{passed:boolean, failures:string[]}}
+ */
+export function checkPhotoViewerPage(response, { id } = {}) {
+  const failures = [];
+  const { status, headers, body } = response;
+
+  if (status !== 200) {
+    failures.push(`HTTP status ${status} (expected 200) for /photo-viewer/${id}`);
+  }
+  const expectedOgUrl = `${SITE_ORIGIN}/photo-viewer/${id}`;
+  const ogUrl = extractMetaContent(body, 'og:url');
+  if (ogUrl !== expectedOgUrl) {
+    failures.push(`og:url is ${ogUrl} (expected ${expectedOgUrl}; 個別OGP未注入? S3 shell?)`);
+  }
+  const ogImage = extractMetaContent(body, 'og:image');
+  if (!ogImage) {
+    failures.push('og:image is missing');
+  } else if (ogImage === GENERIC_OG_IMAGE || ogImage.endsWith('/og-image.png')) {
+    failures.push(`og:image is the generic fallback (${ogImage}); per-photo thumbnail not injected`);
+  } else if (!/^https:\/\//i.test(ogImage)) {
+    failures.push(`og:image is not an absolute https URL: ${ogImage}`);
+  }
+  const xRobotsTag = getHeader(headers, 'x-robots-tag');
+  if (hasNoindex(xRobotsTag)) {
+    failures.push(`X-Robots-Tag noindex present: ${xRobotsTag}`);
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+// ---- sitemap からの監視対象選択（ハイブリッド：壊れてる=fail / 空=skip）§4.2 -----
+
+/**
+ * sitemap レスポンスが「正常な XML」かを判定する補助。
+ * @param {{status:number, contentType:string}} res
+ * @returns {boolean}
+ */
+function looksLikeXml(contentType) {
+  return typeof contentType === 'string' && /xml/i.test(contentType);
+}
+
+/**
+ * sitemap-tags.xml から監視対象 slug を 1 件選ぶ（ハイブリッド）。
+ * - 配信障害（非 200 / XML でない）→ fail
+ * - 正常だが対象 0 件 → skip
+ * - 正常 + slug あり → check
+ * @param {{status:number, contentType:string, body:string}} res
+ * @returns {{action:'check'|'skip'|'fail', slug?:string, reason:string}}
+ */
+export function selectTagSlug(res) {
+  const { status, contentType, body } = res;
+  if (status !== 200) {
+    return { action: 'fail', reason: `sitemap-tags.xml returned HTTP ${status}` };
+  }
+  if (!looksLikeXml(contentType)) {
+    return { action: 'fail', reason: `sitemap-tags.xml is not XML (content-type: ${contentType}; SPA shell?)` };
+  }
+  const slug = firstMatch(body, /\/tags\/([^?<]+)/);
+  if (slug) {
+    return { action: 'check', slug, reason: 'tag slug selected' };
+  }
+  return { action: 'skip', reason: 'no indexable tags in sitemap (empty catalog)' };
+}
+
+/**
+ * sitemap-photos-0.xml から監視対象 id を 1 件選ぶ（ハイブリッド）。
+ * - 404 → skip（公開写真なし。backend が notFound() を返す仕様）
+ * - その他の非 200 / XML でない → fail
+ * - 正常 + id あり → check
+ * @param {{status:number, contentType:string, body:string}} res
+ * @returns {{action:'check'|'skip'|'fail', id?:string, reason:string}}
+ */
+export function selectPhotoId(res) {
+  const { status, contentType, body } = res;
+  if (status === 404) {
+    return { action: 'skip', reason: 'no published photos (sitemap-photos returns 404)' };
+  }
+  if (status !== 200) {
+    return { action: 'fail', reason: `sitemap-photos-0.xml returned HTTP ${status}` };
+  }
+  if (!looksLikeXml(contentType)) {
+    return { action: 'fail', reason: `sitemap-photos-0.xml is not XML (content-type: ${contentType}; SPA shell?)` };
+  }
+  const id = firstMatch(body, /\/photo-viewer\/(\d+)/);
+  if (id) {
+    return { action: 'check', id, reason: 'photo id selected' };
+  }
+  return { action: 'skip', reason: 'empty photos sitemap' };
+}
+
+// ---- 内部ヘルパー -----------------------------------------------------------
+
+function firstMatch(text, regex) {
+  if (!text) {
+    return null;
+  }
+  const m = text.match(regex);
+  return m ? m[1] : null;
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/canary/seo-canary.js
+++ b/scripts/canary/seo-canary.js
@@ -1,0 +1,81 @@
+// Issue#148: CloudWatch Synthetics canary 本体（Synthetics ランタイムで実行される handler）。
+//
+// 本番 photlas.jp の /tags（SSR）・/photo-viewer（個別 OGP）を 30 分おきに外形監視する。
+// 検証ロジックは checks.mjs（単体テスト済み）に委譲し、ここは「sitemap から監視対象を選ぶ →
+// HTTP 取得 → checks に渡す → 失敗があれば throw」だけの薄いラッパー。
+// Synthetics ランタイム（Synthetics/SyntheticsLogger）依存のため単体テスト対象外。
+//
+// 設計（documents/04_Issues/Issue#148.md §3 / §4.2）:
+//   - リダイレクトは追わず、canonical な ?lang=ja を叩く（/tags の 1 ホップ 301 を回避）
+//   - sitemap が「壊れている」なら fail、「正常だが空」ならその URL をスキップ（ハイブリッド）
+
+const log = require('SyntheticsLogger');
+const https = require('node:https');
+
+const SITE_ORIGIN = 'https://photlas.jp';
+const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * リダイレクトを追わずに 1 回だけ GET し、status / headers / body を返す。
+ * @param {string} url
+ * @returns {Promise<{status:number, headers:object, contentType:string, body:string}>}
+ */
+function fetchOnce(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { timeout: REQUEST_TIMEOUT_MS }, (res) => {
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => resolve({
+        status: res.statusCode,
+        headers: res.headers,
+        contentType: res.headers['content-type'] || '',
+        body,
+      }));
+    });
+    req.on('timeout', () => req.destroy(new Error(`request timed out: ${url}`)));
+    req.on('error', reject);
+  });
+}
+
+const handler = async () => {
+  // ESM の純粋ロジックを動的 import（Synthetics ランタイムは CommonJS handler）。
+  const checks = await import('./checks.mjs');
+  const failures = [];
+
+  // ---- /tags（SSR ランディング） ----
+  const tagsSitemap = await fetchOnce(`${SITE_ORIGIN}/api/v1/sitemap-tags.xml`);
+  const tagSel = checks.selectTagSlug(tagsSitemap);
+  log.info(`/tags target selection: ${tagSel.action} (${tagSel.reason})`);
+  if (tagSel.action === 'fail') {
+    failures.push(`/tags sitemap delivery broken: ${tagSel.reason}`);
+  } else if (tagSel.action === 'check') {
+    const res = await fetchOnce(`${SITE_ORIGIN}/tags/${encodeURIComponent(tagSel.slug)}?lang=ja`);
+    const result = checks.checkTagsPage(res, { slug: tagSel.slug });
+    if (!result.passed) {
+      failures.push(...result.failures.map((f) => `/tags/${tagSel.slug}: ${f}`));
+    }
+  }
+
+  // ---- /photo-viewer（個別 OGP） ----
+  const photosSitemap = await fetchOnce(`${SITE_ORIGIN}/api/v1/sitemap-photos-0.xml`);
+  const photoSel = checks.selectPhotoId(photosSitemap);
+  log.info(`/photo-viewer target selection: ${photoSel.action} (${photoSel.reason})`);
+  if (photoSel.action === 'fail') {
+    failures.push(`/photo-viewer sitemap delivery broken: ${photoSel.reason}`);
+  } else if (photoSel.action === 'check') {
+    const res = await fetchOnce(`${SITE_ORIGIN}/photo-viewer/${photoSel.id}`);
+    const result = checks.checkPhotoViewerPage(res, { id: photoSel.id });
+    if (!result.passed) {
+      failures.push(...result.failures.map((f) => `/photo-viewer/${photoSel.id}: ${f}`));
+    }
+  }
+
+  if (failures.length > 0) {
+    // throw すると Synthetics は当該実行を Failed として記録 → SuccessPercent < 100 → アラーム。
+    throw new Error(`SEO canary detected ${failures.length} problem(s):\n- ${failures.join('\n- ')}`);
+  }
+  log.info('SEO canary passed: /tags and /photo-viewer are serving SSR/OGP correctly.');
+};
+
+exports.handler = handler;

--- a/scripts/setup-synthetics-canary.sh
+++ b/scripts/setup-synthetics-canary.sh
@@ -1,0 +1,327 @@
+#!/bin/bash
+#
+# Issue#148: 死活監視 CloudWatch Synthetics canary セットアップスクリプト（冪等）
+#
+# 本番 photlas.jp の SEO 重要 URL を 30 分おきに外形監視し、退化したらアラートする。
+#   - /tags/{slug}?lang=ja        … SSR ランディング（hreflang / canonical / X-Robots-Tag）
+#   - /photo-viewer/{id}          … 個別 OGP（og:url / og:image / X-Robots-Tag）
+# canary 本体ソース: scripts/canary/{seo-canary.js, checks.mjs}
+#
+# 実行内容:
+#   1. 既存 SNS topic photlas-waf-alerts の存在確認（無ければ fail-fast）＋ confirmed 購読の警告
+#   2. アーティファクト用 S3 バケット作成（冪等）
+#   3. canary 実行ロール（IAM）作成（冪等）
+#   4. canary 本体を zip 化し、create-canary / update-canary（冪等）
+#   5. CloudWatch アラーム（SuccessPercent < 100 が 2 回連続）→ photlas-waf-alerts
+#
+# 使い方:
+#   ./scripts/setup-synthetics-canary.sh
+#
+# 前提:
+#   - SNS topic photlas-waf-alerts が存在し、メール購読が confirmed であること
+#     （未確認だとアラートが誰にも届かない）。本番アラート集約先として ./scripts/setup-waf-alarms.sh
+#     で作成済みのトピックを流用する。
+#
+# 備考:
+#   - 通知先 SNS topic は新設せず流用する（Issue#148 §4.1）。
+#   - 発報時の対応手順は scripts/canary/README.md（triage runbook）を参照。
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# 設定
+# -----------------------------------------------------------------------------
+
+AWS_REGION="ap-northeast-1"
+SITE_ORIGIN="https://photlas.jp"
+
+CANARY_NAME="photlas-seo-canary"
+RUNTIME_VERSION="syn-nodejs-puppeteer-9.1"
+SCHEDULE_EXPRESSION="rate(30 minutes)"
+HANDLER="seo-canary.handler"
+
+SNS_TOPIC_NAME="photlas-waf-alerts"
+ALARM_NAME="photlas-seo-canary-SuccessPercent"
+IAM_ROLE_NAME="photlas-synthetics-canary-role"
+
+CANARY_SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/canary" && pwd)"
+
+# 適用するリソースタグ（既存 setup-waf-alarms.sh 等の規約に合わせる。'#' は使えないのでハイフン）。
+TAG_PROJECT="Photlas"
+TAG_ENVIRONMENT="production"
+TAG_MANAGED_BY="Issue-148"
+TAG_COST_CENTER="monitoring"
+
+# -----------------------------------------------------------------------------
+# ヘルパー
+# -----------------------------------------------------------------------------
+
+log() {
+  echo "[$(date '+%H:%M:%S')] $*"
+}
+
+section() {
+  echo ""
+  echo "=== $* ==="
+}
+
+# -----------------------------------------------------------------------------
+# 事前情報
+# -----------------------------------------------------------------------------
+
+section "Pre-flight"
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query 'Account' --output text)"
+log "Account: $ACCOUNT_ID / Region: $AWS_REGION"
+
+ARTIFACT_BUCKET="photlas-synthetics-artifacts-${ACCOUNT_ID}"
+ARTIFACT_S3_LOCATION="s3://${ARTIFACT_BUCKET}/canary/${CANARY_NAME}"
+
+# -----------------------------------------------------------------------------
+# 1. SNS topic（流用。存在確認のみ。新規作成はしない）
+# -----------------------------------------------------------------------------
+
+section "Step 1: SNS topic (reuse $SNS_TOPIC_NAME)"
+
+SNS_TOPIC_ARN="$(aws sns list-topics \
+  --region "$AWS_REGION" \
+  --query "Topics[?ends_with(TopicArn, ':${SNS_TOPIC_NAME}')].TopicArn | [0]" \
+  --output text)"
+
+if [ -z "$SNS_TOPIC_ARN" ] || [ "$SNS_TOPIC_ARN" = "None" ]; then
+  echo "ERROR: SNS topic '$SNS_TOPIC_NAME' not found." >&2
+  echo "       Run ./scripts/setup-waf-alarms.sh first (it creates photlas-waf-alerts)." >&2
+  exit 1
+fi
+log "SNS topic ARN: $SNS_TOPIC_ARN"
+
+# confirmed な購読が 1 つも無ければ、発報しても誰にも届かないため警告する。
+CONFIRMED_SUBS="$(aws sns list-subscriptions-by-topic \
+  --region "$AWS_REGION" \
+  --topic-arn "$SNS_TOPIC_ARN" \
+  --query "length(Subscriptions[?SubscriptionArn!='PendingConfirmation' && SubscriptionArn!='Deleted'])" \
+  --output text)"
+
+if [ "$CONFIRMED_SUBS" = "0" ]; then
+  log "WARNING: topic '$SNS_TOPIC_NAME' has no confirmed subscription."
+  log "         Alerts will be delivered to no one until a subscription is confirmed."
+else
+  log "Confirmed subscriptions: $CONFIRMED_SUBS"
+fi
+
+# -----------------------------------------------------------------------------
+# 2. アーティファクト用 S3 バケット（冪等）
+# -----------------------------------------------------------------------------
+
+section "Step 2: Artifacts bucket"
+
+if aws s3api head-bucket --bucket "$ARTIFACT_BUCKET" --region "$AWS_REGION" 2>/dev/null; then
+  log "Artifacts bucket exists: $ARTIFACT_BUCKET"
+else
+  log "Creating artifacts bucket: $ARTIFACT_BUCKET"
+  aws s3 mb "s3://${ARTIFACT_BUCKET}" --region "$AWS_REGION"
+fi
+
+# -----------------------------------------------------------------------------
+# 3. canary 実行ロール（IAM、冪等）
+# -----------------------------------------------------------------------------
+
+section "Step 3: IAM execution role"
+
+if aws iam get-role --role-name "$IAM_ROLE_NAME" >/dev/null 2>&1; then
+  log "IAM role exists: $IAM_ROLE_NAME"
+else
+  log "Creating IAM role: $IAM_ROLE_NAME"
+  TRUST_DOC="$(mktemp)"
+  cat > "$TRUST_DOC" <<'JSON'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Principal": { "Service": "lambda.amazonaws.com" }, "Action": "sts:AssumeRole" }
+  ]
+}
+JSON
+  aws iam create-role \
+    --role-name "$IAM_ROLE_NAME" \
+    --assume-role-policy-document "file://${TRUST_DOC}" \
+    --tags \
+      "Key=Project,Value=${TAG_PROJECT}" \
+      "Key=Environment,Value=${TAG_ENVIRONMENT}" \
+      "Key=ManagedBy,Value=${TAG_MANAGED_BY}" \
+      "Key=CostCenter,Value=${TAG_COST_CENTER}"
+  rm -f "$TRUST_DOC"
+
+  PERM_DOC="$(mktemp)"
+  cat > "$PERM_DOC" <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetBucketLocation"],
+      "Resource": ["arn:aws:s3:::${ARTIFACT_BUCKET}/*", "arn:aws:s3:::${ARTIFACT_BUCKET}"]
+    },
+    { "Effect": "Allow", "Action": ["s3:ListAllMyBuckets"], "Resource": "*" },
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:aws:logs:${AWS_REGION}:${ACCOUNT_ID}:log-group:/aws/lambda/cwsyn-${CANARY_NAME}-*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["cloudwatch:PutMetricData"],
+      "Resource": "*",
+      "Condition": { "StringEquals": { "cloudwatch:namespace": "CloudWatchSynthetics" } }
+    }
+  ]
+}
+JSON
+  aws iam put-role-policy \
+    --role-name "$IAM_ROLE_NAME" \
+    --policy-name "photlas-synthetics-canary-policy" \
+    --policy-document "file://${PERM_DOC}"
+  rm -f "$PERM_DOC"
+fi
+
+ROLE_ARN="$(aws iam get-role --role-name "$IAM_ROLE_NAME" --query 'Role.Arn' --output text)"
+log "Execution role ARN: $ROLE_ARN"
+
+# -----------------------------------------------------------------------------
+# 4. canary 本体を zip 化し、create / update（冪等）
+# -----------------------------------------------------------------------------
+
+section "Step 4: Package and deploy canary"
+
+# Synthetics の nodejs canary はコードを nodejs/node_modules/ 配下に置く必要がある。
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+mkdir -p "$BUILD_DIR/nodejs/node_modules"
+cp "$CANARY_SRC_DIR/seo-canary.js" "$BUILD_DIR/nodejs/node_modules/"
+cp "$CANARY_SRC_DIR/checks.mjs" "$BUILD_DIR/nodejs/node_modules/"
+ZIP_PATH="$BUILD_DIR/canary.zip"
+( cd "$BUILD_DIR" && zip -r -q "$ZIP_PATH" nodejs )
+log "Packaged canary: $ZIP_PATH (monitoring $SITE_ORIGIN)"
+
+# --code の shorthand 内 ZipFile=fileb:// は CLI がファイルとして読まない（base64 文字列扱い）ため、
+# zip を S3 にアップロードして S3Bucket/S3Key で参照する。
+CODE_S3_KEY="canary/${CANARY_NAME}/source/canary.zip"
+log "Uploading canary code to s3://${ARTIFACT_BUCKET}/${CODE_S3_KEY}"
+aws s3 cp "$ZIP_PATH" "s3://${ARTIFACT_BUCKET}/${CODE_S3_KEY}" --region "$AWS_REGION"
+CODE_SPEC="S3Bucket=${ARTIFACT_BUCKET},S3Key=${CODE_S3_KEY},Handler=${HANDLER}"
+
+if aws synthetics get-canary --name "$CANARY_NAME" --region "$AWS_REGION" >/dev/null 2>&1; then
+  log "Canary exists; updating: $CANARY_NAME"
+  # update-canary は RUNNING 中の canary には使えないため、実行中なら先に停止する（冪等性確保）。
+  PRE_STATE="$(aws synthetics get-canary --name "$CANARY_NAME" --region "$AWS_REGION" \
+    --query 'Canary.Status.State' --output text)"
+  if [ "$PRE_STATE" = "RUNNING" ]; then
+    log "Canary is RUNNING; stopping before update..."
+    aws synthetics stop-canary --name "$CANARY_NAME" --region "$AWS_REGION"
+    for _ in $(seq 1 40); do
+      PRE_STATE="$(aws synthetics get-canary --name "$CANARY_NAME" --region "$AWS_REGION" \
+        --query 'Canary.Status.State' --output text)"
+      case "$PRE_STATE" in STOPPED|READY) break ;; esac
+      log "  state: $PRE_STATE (stopping...)"
+      sleep 5
+    done
+  fi
+  aws synthetics update-canary \
+    --name "$CANARY_NAME" \
+    --region "$AWS_REGION" \
+    --execution-role-arn "$ROLE_ARN" \
+    --runtime-version "$RUNTIME_VERSION" \
+    --schedule "Expression=${SCHEDULE_EXPRESSION}" \
+    --run-config "TimeoutInSeconds=60" \
+    --code "$CODE_SPEC"
+else
+  log "Creating canary: $CANARY_NAME"
+  aws synthetics create-canary \
+    --name "$CANARY_NAME" \
+    --region "$AWS_REGION" \
+    --artifact-s3-location "$ARTIFACT_S3_LOCATION" \
+    --execution-role-arn "$ROLE_ARN" \
+    --runtime-version "$RUNTIME_VERSION" \
+    --schedule "Expression=${SCHEDULE_EXPRESSION}" \
+    --run-config "TimeoutInSeconds=60" \
+    --code "$CODE_SPEC" \
+    --tags "Project=${TAG_PROJECT},Environment=${TAG_ENVIRONMENT},ManagedBy=${TAG_MANAGED_BY},CostCenter=${TAG_COST_CENTER}"
+fi
+
+# create-canary / update-canary は CREATING / UPDATING のまま即座に返る。
+# RUNNING でない状態（READY/STOPPED）に落ち着くまで待ってから start する（CREATING 中は start 不可）。
+log "Waiting for canary to settle (CREATING/UPDATING -> READY)..."
+CANARY_STATE=""
+for _ in $(seq 1 40); do
+  CANARY_STATE="$(aws synthetics get-canary --name "$CANARY_NAME" --region "$AWS_REGION" \
+    --query 'Canary.Status.State' --output text)"
+  case "$CANARY_STATE" in
+    READY|STOPPED|RUNNING) break ;;
+    ERROR)
+      echo "ERROR: canary entered ERROR state." >&2
+      aws synthetics get-canary --name "$CANARY_NAME" --region "$AWS_REGION" --query 'Canary.Status' >&2
+      exit 1
+      ;;
+  esac
+  log "  state: $CANARY_STATE (waiting...)"
+  sleep 5
+done
+
+if [ "$CANARY_STATE" != "RUNNING" ]; then
+  log "Starting canary: $CANARY_NAME"
+  aws synthetics start-canary --name "$CANARY_NAME" --region "$AWS_REGION"
+fi
+
+# -----------------------------------------------------------------------------
+# 5. CloudWatch アラーム（SuccessPercent < 100 が 2 回連続 → 発報）
+# -----------------------------------------------------------------------------
+
+section "Step 5: CloudWatch alarm"
+
+# put-metric-alarm は同名なら上書き（冪等）。
+# 2 回連続失敗で発報（§4.1）。canary が止まると欠損 → breaching で異常検知。
+# 復旧時は ok-actions で通知（§4.2）。
+log "Creating/updating alarm: $ALARM_NAME"
+aws cloudwatch put-metric-alarm \
+  --region "$AWS_REGION" \
+  --alarm-name "$ALARM_NAME" \
+  --alarm-description "Issue#148: photlas.jp /tags SSR & /photo-viewer OGP death monitoring (fires after 2 consecutive canary failures)" \
+  --namespace "CloudWatchSynthetics" \
+  --metric-name "SuccessPercent" \
+  --dimensions "Name=CanaryName,Value=${CANARY_NAME}" \
+  --statistic "Average" \
+  --period 1800 \
+  --evaluation-periods 2 \
+  --datapoints-to-alarm 2 \
+  --threshold 100 \
+  --comparison-operator "LessThanThreshold" \
+  --treat-missing-data "breaching" \
+  --alarm-actions "$SNS_TOPIC_ARN" \
+  --ok-actions "$SNS_TOPIC_ARN" \
+  --tags \
+    "Key=Project,Value=${TAG_PROJECT}" \
+    "Key=Environment,Value=${TAG_ENVIRONMENT}" \
+    "Key=ManagedBy,Value=${TAG_MANAGED_BY}" \
+    "Key=CostCenter,Value=${TAG_COST_CENTER}"
+
+# -----------------------------------------------------------------------------
+# 完了
+# -----------------------------------------------------------------------------
+
+section "Setup complete"
+
+cat <<EOF
+
+Synthetics canary setup completed.
+
+  Canary:       ${CANARY_NAME} (${SCHEDULE_EXPRESSION}, ${RUNTIME_VERSION})
+  Monitors:     ${SITE_ORIGIN}/tags/{slug}?lang=ja , ${SITE_ORIGIN}/photo-viewer/{id}
+  Artifacts:    ${ARTIFACT_S3_LOCATION}
+  Exec role:    ${IAM_ROLE_NAME}
+  Alarm:        ${ALARM_NAME} (SuccessPercent < 100, 2/2 datapoints)
+  Notify (SNS): ${SNS_TOPIC_ARN}
+
+Next steps:
+  1. Confirm the canary's first run succeeds in the CloudWatch Synthetics console.
+  2. (Verification) Temporarily break a condition and confirm the alarm fires.
+     See scripts/canary/README.md (triage runbook).
+EOF

--- a/tests/scripts/setup-app-ratelimit-alarm.bats
+++ b/tests/scripts/setup-app-ratelimit-alarm.bats
@@ -66,7 +66,10 @@ SCRIPT="$SCRIPTS_DIR/setup-app-ratelimit-alarm.sh"
   assert_contains "$SCRIPT" 'photlas-app-ratelimit-exceeded-filter'
 }
 
-@test "setup-app-ratelimit-alarm.sh: filter pattern matches レート制限超過 log message" {
+# NOTE(Issue#148): @test 名は ASCII のみにする。テスト名に日本語（マルチバイト）が
+# 含まれると bats 1.13 がそのテストを取りこぼし、ディレクトリ実行が exit 1 になるため。
+# 検証対象の日本語ログ文言（レート制限超過）は下の assert 側でそのまま確認する。
+@test "setup-app-ratelimit-alarm.sh: filter pattern matches the rate-limit-exceeded log message" {
   assert_contains "$SCRIPT" 'レート制限超過'
 }
 

--- a/tests/scripts/setup-synthetics-canary.bats
+++ b/tests/scripts/setup-synthetics-canary.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+#
+# Specification-driven tests for scripts/setup-synthetics-canary.sh
+# Source of truth: documents/04_Issues/Issue#148.md §4 / §4.1 / §4.2 / §6.1
+#
+# Verifies the script:
+#   - is syntactically valid (shellcheck passes), bash + strict mode
+#   - targets ap-northeast-1 and the prod site photlas.jp
+#   - creates ONE CloudWatch Synthetics canary (syn-nodejs-puppeteer runtime,
+#     30-minute schedule) from the scripts/canary/ source
+#   - is idempotent (get-canary → update-canary or create-canary)
+#   - reuses the existing SNS topic photlas-waf-alerts and does NOT create one,
+#     verifies the topic exists (fail-fast) and warns on no confirmed subscription
+#   - creates a CloudWatch alarm on SuccessPercent < 100 that fires only after
+#     2 consecutive failures (evaluation-periods 2 / datapoints-to-alarm 2),
+#     wiring BOTH alarm-actions and ok-actions to the SNS topic
+#   - provisions a canary IAM role and an artifacts S3 bucket
+#   - tags resources with Project/Environment/ManagedBy=Issue-148
+
+load helpers
+
+SCRIPT="$SCRIPTS_DIR/setup-synthetics-canary.sh"
+
+@test "setup-synthetics-canary.sh: exists and is executable" {
+  assert_script_executable "$SCRIPT"
+}
+
+@test "setup-synthetics-canary.sh: passes shellcheck" {
+  assert_shellcheck_passes "$SCRIPT"
+}
+
+@test "setup-synthetics-canary.sh: uses bash shebang" {
+  assert_matches "$SCRIPT" '^#!/bin/bash'
+}
+
+@test "setup-synthetics-canary.sh: enables strict mode (set -euo pipefail)" {
+  assert_contains "$SCRIPT" 'set -euo pipefail'
+}
+
+@test "setup-synthetics-canary.sh: targets ap-northeast-1 region" {
+  assert_contains "$SCRIPT" 'ap-northeast-1'
+}
+
+@test "setup-synthetics-canary.sh: monitors the prod site photlas.jp" {
+  assert_contains "$SCRIPT" 'photlas.jp'
+}
+
+# --- Canary creation --------------------------------------------------------
+
+@test "setup-synthetics-canary.sh: creates a Synthetics canary" {
+  assert_contains "$SCRIPT" 'aws synthetics create-canary'
+}
+
+@test "setup-synthetics-canary.sh: uses the syn-nodejs-puppeteer runtime" {
+  assert_matches "$SCRIPT" 'syn-nodejs-puppeteer'
+}
+
+@test "setup-synthetics-canary.sh: schedules the canary every 30 minutes" {
+  assert_contains "$SCRIPT" 'rate(30 minutes)'
+}
+
+@test "setup-synthetics-canary.sh: bundles the scripts/canary source" {
+  assert_contains "$SCRIPT" 'scripts/canary'
+}
+
+@test "setup-synthetics-canary.sh: is idempotent (checks existence via get-canary)" {
+  assert_contains "$SCRIPT" 'aws synthetics get-canary'
+}
+
+@test "setup-synthetics-canary.sh: updates the canary when it already exists" {
+  assert_contains "$SCRIPT" 'aws synthetics update-canary'
+}
+
+# --- SNS topic reuse (Issue + setup-cloudwatch-alarms.sh) -------------------
+
+@test "setup-synthetics-canary.sh: reuses the existing SNS topic photlas-waf-alerts" {
+  assert_contains "$SCRIPT" 'photlas-waf-alerts'
+}
+
+@test "setup-synthetics-canary.sh: does NOT create a new SNS topic" {
+  run grep -E 'aws sns create-topic' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}
+
+@test "setup-synthetics-canary.sh: fails fast if the SNS topic does not exist" {
+  # 既存トピックの存在確認に list-topics か get-topic-attributes を使う
+  run bash -c "grep -Eq 'aws sns (list-topics|get-topic-attributes)' '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "setup-synthetics-canary.sh: checks for a confirmed subscription" {
+  assert_contains "$SCRIPT" 'list-subscriptions-by-topic'
+}
+
+# --- CloudWatch alarm -------------------------------------------------------
+
+@test "setup-synthetics-canary.sh: creates a CloudWatch alarm" {
+  assert_contains "$SCRIPT" 'aws cloudwatch put-metric-alarm'
+}
+
+@test "setup-synthetics-canary.sh: alarms on the SuccessPercent metric" {
+  assert_contains "$SCRIPT" 'SuccessPercent'
+}
+
+@test "setup-synthetics-canary.sh: uses the CloudWatchSynthetics namespace" {
+  assert_contains "$SCRIPT" 'CloudWatchSynthetics'
+}
+
+@test "setup-synthetics-canary.sh: fires only after 2 consecutive failures" {
+  assert_matches "$SCRIPT" '--evaluation-periods[ =]+2'
+  assert_matches "$SCRIPT" '--datapoints-to-alarm[ =]+2'
+}
+
+@test "setup-synthetics-canary.sh: compares SuccessPercent below threshold 100" {
+  assert_contains "$SCRIPT" 'LessThanThreshold'
+  assert_matches "$SCRIPT" '--threshold[ =]+100'
+}
+
+@test "setup-synthetics-canary.sh: wires both alarm-actions and ok-actions to SNS" {
+  assert_contains "$SCRIPT" '--alarm-actions'
+  assert_contains "$SCRIPT" '--ok-actions'
+}
+
+# --- IAM role / artifacts bucket / tags -------------------------------------
+
+@test "setup-synthetics-canary.sh: provisions a canary IAM role" {
+  assert_matches "$SCRIPT" 'iam (create-role|get-role)'
+}
+
+@test "setup-synthetics-canary.sh: uses an S3 artifacts location" {
+  assert_matches "$SCRIPT" 's3://|ArtifactS3Location|artifact'
+}
+
+@test "setup-synthetics-canary.sh: tags resources with ManagedBy=Issue-148" {
+  assert_contains "$SCRIPT" 'Issue-148'
+}
+
+@test "setup-synthetics-canary.sh: tags resources with Project=Photlas" {
+  assert_contains "$SCRIPT" 'Photlas'
+}


### PR DESCRIPTION
## 概要 (Issue#148)
本番 photlas.jp の SEO 重要 URL を 30 分おきに外形監視し、デプロイと無関係な配信障害（CloudFront/ALB ドリフト、X-Robots-Tag 誤付与、S3 殻フォールバック等）を継続検知する CloudWatch Synthetics canary を追加。

## 監視内容（§3）
- `/tags/{slug}?lang=ja`: HTTP 200 / hreflang≥5 / canonical 絶対URL / X-Robots-Tag noindex なし
- `/photo-viewer/{id}`: HTTP 200 / og:url 個別 / og:image が CDN サムネ / X-Robots-Tag noindex なし
- 監視対象 slug/id は sitemap から動的取得（壊れてる=fail / 空=skip のハイブリッド）

## 成果物
- `scripts/canary/checks.mjs` … 検証ロジック（純粋関数）
- `scripts/canary/seo-canary.js` … Synthetics handler
- `scripts/setup-synthetics-canary.sh` … 冪等デプロイ（canary/IAM/S3/アラーム、photlas-waf-alerts 流用）
- `scripts/canary/README.md` … 発報時 triage runbook
- `tests/scripts/setup-synthetics-canary.bats` / `scripts/canary/__tests__/checks.test.js` … TDD
- `.github/workflows/ci.yml` … canary JS テストステップ追加

## テスト・検証
- TDD: checks.test.js 25件 / bats 26件、shellcheck・全 bats・全 JS green
- 本番デプロイ済み（canary 稼働・初回 PASSED）
- E-4 意図的失敗テスト: 失敗→ALARM 発報→SNS 通知→復旧→OK を実機確認

## 通知先
既存 `photlas-waf-alerts`（confirmed 購読 support@photlas.jp）を流用。SuccessPercent<100 が 2 回連続で発報。